### PR TITLE
remove unwanted log

### DIFF
--- a/firecrasher/src/main/java/com/osama/firecrasher/CrashHandler.java
+++ b/firecrasher/src/main/java/com/osama/firecrasher/CrashHandler.java
@@ -2,11 +2,9 @@ package com.osama.firecrasher;
 
 import android.app.Activity;
 import android.app.ActivityManager;
-import android.app.AlertDialog;
 import android.app.Application;
 import android.content.Context;
 import android.os.Bundle;
-import android.util.Log;
 
 import java.util.List;
 
@@ -70,7 +68,6 @@ public final class CrashHandler implements Thread.UncaughtExceptionHandler {
                 crashListener.onCrash(throwable);
             } 
         });
-        Log.e("FireCrasher.err", thread.getName(), throwable);
     }
 
     Application.ActivityLifecycleCallbacks getLifecycleCallbacks() {


### PR DESCRIPTION
The library should not log it self the error.
It should be up to the user to log or not.

For example: 
In a black-box library which uses fireCrasher and catches an exception of the integrating app, to comply with privacy rules it should not expose the potentially sensitive data.