### PR TITLE
remove tag application declaration in the library manifest 

### DIFF
--- a/firecrasher/src/main/AndroidManifest.xml
+++ b/firecrasher/src/main/AndroidManifest.xml
@@ -1,11 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.osama.firecrasher">
-
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
-</manifest>
+<manifest package="com.osama.firecrasher"/>


### PR DESCRIPTION
This setting could cause unwanted behaviours in the integrating projects. It is not a responsability of the library to define these settings. 