### PR TITLE
Add configurable recovery policy, lambda install, and uninstall

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ live in `firecrasher/AGENTS.md` and `app/AGENTS.md`.
 **FireCrasher** is an Android library that catches uncaught exceptions and
 runs a staged **recovery** sequence to keep the app alive instead of letting
 it die. It is published to JitPack as `com.github.osama-raddad:FireCrasher`.
-Current version is **2.1.0**.
+Current version is **2.2.0**.
 
 The recovery escalation ladder has three levels (`CrashLevel`):
 
@@ -38,9 +38,11 @@ This is a two-module Gradle project (`settings.gradle`):
 
 | File | Role |
 |------|------|
-| `FireCrasher.kt` | Public API entry point (Kotlin `object`). `install`, `evaluate`, `recover`, and the `ApplicationExitInfo` query helpers. Holds `retryCount` and the recovery-state persistence logic. |
-| `CrashHandler.java` | `Thread.UncaughtExceptionHandler` + `ActivityLifecycleCallbacks`. Tracks the current activity and the live activity count (`getBackStackCount`). Delivers crashes to the listener on the main thread. |
-| `FireLooper.kt` | Reflection-based replacement main loop that survives exceptions. `isSafe` guards against double-install. |
+| `FireCrasher.kt` | Public API entry point (Kotlin `object`). `install` (listener and `CrashEvent`-lambda overloads), `uninstall`, `evaluate`, `recover`, and the `ApplicationExitInfo` query helpers. Holds `retryCount` and the recovery-state persistence logic. |
+| `FireCrasherConfig.kt` | Recovery-policy configuration: `Builder`, `RecoveryPredicate` (shouldRecover filter), `BackStackDepthProvider` (single-activity/Compose depth), the LEVEL_ONE retry threshold, and the crash-loop breaker settings (on by default: 10 crashes / 60 s). |
+| `CrashEvent.kt` | Crash context delivered to the lambda install form: throwable, thread, activity, retryCount, suggestedLevel, plus `recover()` shortcuts. Internal constructor so fields can be added compatibly. |
+| `CrashHandler.java` | `Thread.UncaughtExceptionHandler` + `ActivityLifecycleCallbacks`. Tracks the current activity and the live activity count (`getBackStackCount`). Applies `shouldRecover` and the crash-loop breaker; declined crashes chain to the pre-install default handler. Delivers accepted crashes to the listener on the main thread. |
+| `FireLooper.kt` | Reflection-based replacement main loop that survives exceptions. `isSafe` guards against double-install; `uninstall()` posts the EXIT sentinel to hand control back to the framework loop. |
 | `CrashListener.kt` | Abstract callback the consumer implements: `onCrash` (required), `onPreviousProcessExit` (optional), plus protected `recover`/`evaluate` helpers. |
 | `CrashLevel.kt` | The three-level recovery enum. |
 | `RecoveryState.kt` | `RecoveryState` data class + `RecoveryStateCodec` — encodes recovery progress into a ≤128-byte blob stored via `ActivityManager.setProcessStateSummary` so recovery escalation survives process death (API 30+). |
@@ -50,12 +52,23 @@ This is a two-module Gradle project (`settings.gradle`):
 JVM unit tests run under **Robolectric** (no device/emulator needed):
 
 - `CrashLevelEvaluationTest` — the level-selection logic (pure `evaluate`).
+- `ConfigEvaluationTest` — the configurable retry threshold and `Builder` validation.
 - `BackStackCountTest` — activity counting via lifecycle callbacks.
 - `CrashHandlerTest` — crash delivery to the listener.
+- `ShouldRecoverTest` — the `shouldRecover` filter and the die-normally path
+  (previous-handler chaining, injectable process terminator).
+- `CrashLoopBreakerTest` — the sliding-window breaker with an injected clock.
+- `LambdaInstallTest` — `CrashEvent` delivery and `backStackDepthProvider`.
+- `UninstallTest` — handler restoration and reinstall.
 - `GoBackDispatchTest` — LEVEL_TWO uses `OnBackPressedDispatcher` for
   `ComponentActivity`, legacy `onBackPressed()` for plain activities.
 - `ExitInfoTest` — `ApplicationExitInfo` querying (`@Config(sdk = [30, 36])`).
 - `RecoveryStateCodecTest` — encode/decode round-trips and the 128-byte limit.
+
+Tests that install FireCrasher must use the internal
+`install(..., hookMainLooper = false)` seam: the real replacement loop blocks
+in `MessageQueue.next()` by design, which would park Robolectric's main
+thread forever.
 
 ## Build & test
 
@@ -110,7 +123,7 @@ Match the language of the file you're editing.
 reporting, the "What's new" changelog). When you change public behavior, the
 supported SDK range, or the version, update `README.md` — especially the
 version in the install snippet and the `VERSION_NAME` default in
-`firecrasher/build.gradle` (currently `2.1.0`).
+`firecrasher/build.gradle` (currently `2.2.0`).
 
 ## Publishing
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,13 @@
 - [Quick start](#quick-start)
 - [Usage](#usage)
   - [Report crashes while recovering](#report-crashes-while-recovering)
+  - [Configure the recovery policy](#configure-the-recovery-policy)
   - [React to the crash level](#react-to-the-crash-level)
+  - [Single-activity and Jetpack Compose apps](#single-activity-and-jetpack-compose-apps)
   - [Detect native crashes and ANRs (API 30+)](#detect-native-crashes-and-anrs-api-30)
+  - [Turning FireCrasher off](#turning-firecrasher-off)
 - [API reference](#api-reference)
+- [What's new in 2.2.0](#whats-new-in-220)
 - [What's new in 2.1.0](#whats-new-in-210)
 - [Documentation](#documentation)
 - [Contributing](#contributing)
@@ -93,26 +97,36 @@ dependencyResolutionManagement {
 
 ```groovy
 dependencies {
-    implementation 'com.github.osama-raddad:FireCrasher:2.1.0'
+    implementation 'com.github.osama-raddad:FireCrasher:2.2.0'
 }
 ```
 
 ## Quick start
 
 Install FireCrasher in your `Application.onCreate` — before any activity is
-created — and start recovery from `onCrash`:
+created — and start recovery from the crash callback:
 
 ```kotlin
 class App : Application() {
     override fun onCreate() {
         super.onCreate()
-        FireCrasher.install(this, object : CrashListener() {
-            override fun onCrash(throwable: Throwable) {
-                recover()
-            }
-        })
+        FireCrasher.install(this) { crash ->
+            crash.recover()
+        }
     }
 }
+```
+
+The lambda receives a [`CrashEvent`](#crashevent) with the throwable and its
+context (thread, activity, retry count, suggested level). The subclass form
+still works — use it when you also need `onPreviousProcessExit`:
+
+```kotlin
+FireCrasher.install(this, object : CrashListener() {
+    override fun onCrash(throwable: Throwable) {
+        recover()
+    }
+})
 ```
 
 Register the Application in your manifest if it isn't already:
@@ -134,13 +148,49 @@ Because the app survives, these reach your reporter as *non-fatal / handled*
 exceptions.
 
 ```kotlin
-FireCrasher.install(this, object : CrashListener() {
-    override fun onCrash(throwable: Throwable) {
-        FirebaseCrashlytics.getInstance().recordException(throwable)   // or Sentry, Bugsnag, …
-        recover()
-    }
-})
+FireCrasher.install(this) { crash ->
+    FirebaseCrashlytics.getInstance().recordException(crash.throwable)   // or Sentry, Bugsnag, …
+    crash.recover()
+}
 ```
+
+### Configure the recovery policy
+
+Pass a `FireCrasherConfig` to `install` to control how much FireCrasher
+retries, which throwables it recovers, and when it gives up:
+
+```kotlin
+val config = FireCrasherConfig.Builder()
+    // Restart the crashing activity this many times before escalating (default 2).
+    .setLevelOneRetries(2)
+    // Let JVM errors (OutOfMemoryError, StackOverflowError, …) kill the app
+    // normally instead of recovering. Default: recover everything.
+    .setShouldRecover { it !is Error }
+    // Stop recovering after 10 crashes within 60s — the app then dies exactly
+    // as it would without FireCrasher, and your crash reporter still gets the
+    // fatal. This is the default; disableCrashLoopBreaker() turns it off.
+    .setCrashLoopBreaker(10, 60_000L)
+    .build()
+
+FireCrasher.install(this, config) { crash ->
+    report(crash.throwable)
+    crash.recover()
+}
+```
+
+The same builder works from Java — `RecoveryPredicate` is a SAM interface:
+
+```java
+FireCrasherConfig config = new FireCrasherConfig.Builder()
+        .setShouldRecover(t -> !(t instanceof Error))
+        .build();
+FireCrasher.install(this, config, new CrashListener() { ... });
+```
+
+When recovery is declined — by `shouldRecover` or the crash-loop breaker — the
+exception goes to whatever `Thread.getDefaultUncaughtExceptionHandler()` was
+installed **before** FireCrasher (typically your crash reporter's), so fatals
+are reported exactly as they would be without FireCrasher.
 
 ### React to the crash level
 
@@ -171,6 +221,33 @@ You can also force a specific level: `recover(CrashLevel.LEVEL_THREE)`.
 
 > **Tip:** keep recovery UX fast and non-blocking — the user just hit a crash, so
 > a brief spinner or toast beats a modal dialog. Do the reporting before showing UX.
+
+### Single-activity and Jetpack Compose apps
+
+FireCrasher counts *activities* to decide whether there is somewhere to go
+back to (LEVEL_TWO). A single-activity app — the usual shape of a Jetpack
+Compose app — always reports zero depth, so the ladder would jump from
+restarting the activity straight to relaunching the whole app.
+
+Tell FireCrasher about your navigation stack instead with
+`setBackStackDepthProvider`. Going back is dispatched through
+`OnBackPressedDispatcher`, which Navigation Compose participates in — so
+LEVEL_TWO pops the crashed *destination* and keeps the rest of your app alive:
+
+```kotlin
+// Hold a reference your Application can reach, e.g. set from your activity:
+var navDepth: () -> Int = { 0 }
+
+val config = FireCrasherConfig.Builder()
+    .setBackStackDepthProvider { navDepth() }
+    .build()
+
+// In your composable host, keep it current:
+navDepth = { navController.previousBackStackEntry?.let { 1 } ?: 0 }
+```
+
+`install()` still belongs in `Application.onCreate` — nothing else is
+Compose-specific.
 
 ### Detect native crashes and ANRs (API 30+)
 
@@ -212,6 +289,22 @@ Both return empty/null below API 30, so no version guard is needed in your code.
 The same record persists across launches — de-duplicate on `exitInfo.timestamp`
 so you don't report the same death twice.
 
+### Turning FireCrasher off
+
+`uninstall()` undoes `install()`: the pre-install default exception handler is
+restored, the replacement main loop exits at its next message, and subsequent
+crashes behave as if FireCrasher was never there. Useful as a remote-config
+kill switch or for A/B-testing recovery:
+
+```kotlin
+if (!remoteConfig.getBoolean("firecrasher_enabled")) {
+    FireCrasher.uninstall()
+}
+```
+
+`install()` may be called again later. Don't call `uninstall()` from inside
+the crash callback itself.
+
 ## API reference
 
 Everything lives in the `com.osama.firecrasher` package.
@@ -220,12 +313,34 @@ Everything lives in the `com.osama.firecrasher` package.
 
 | Member | Description |
 |--------|-------------|
-| `install(application, listener)` | Hook the main loop and activity lifecycle. Call once, in `Application.onCreate`. |
+| `install(application) { crash -> … }` | Hook the main loop and activity lifecycle, with a [`CrashEvent`](#crashevent) lambda. Call once, in `Application.onCreate`. |
+| `install(application, config) { crash -> … }` | Same, with a [`FireCrasherConfig`](#firecrasherconfig). |
+| `install(application, [config,] listener)` | Subclass form; needed for `onPreviousProcessExit`. |
+| `uninstall()` | Undo `install()` — restore the previous handler and stop the replacement loop. |
 | `retryCount: Int` | How many times recovery has retried the current crash (read-only). |
 | `evaluate(): CrashLevel` | The level recovery would use right now. |
-| `recover(level = evaluate(), onRecover)` | Run recovery, optionally at a forced level, with a callback after it starts. |
+| `recover(level = evaluate(), onRecover = null)` | Run recovery, optionally at a forced level, with an optional callback after it starts. |
 | `getLastAbnormalExit(context)` | Most recent crash / native crash / ANR exit record, or `null`. API 30+. |
 | `getHistoricalExitReasons(context, maxCount = 16)` | Past process exits, newest first. API 30+. |
+
+### `FireCrasherConfig`
+
+Built with `FireCrasherConfig.Builder`; pass to `install`. `DEFAULT` preserves
+historical behavior except the crash-loop breaker, which defaults to on.
+
+| Builder method | Description |
+|--------|-------------|
+| `setLevelOneRetries(count)` | Crashes absorbed by restarting the same activity before escalating (default 2). |
+| `setShouldRecover(predicate)` | `RecoveryPredicate` consulted per crash; `false` hands the crash to the previous default handler (default: recover everything). |
+| `setCrashLoopBreaker(maxCrashes, windowMillis)` | Stop recovering after this many crashes inside the window (default 10 / 60 000 ms). |
+| `disableCrashLoopBreaker()` | Restore the pre-2.2.0 always-recover behavior. |
+| `setBackStackDepthProvider(provider)` | Report your own navigation depth (single-activity / Compose apps). |
+
+### `CrashEvent`
+
+Delivered to the `install` lambda. Properties: `throwable`, `thread`,
+`activity` (nullable), `retryCount`, `suggestedLevel`. Methods: `recover()`
+and `recover(level)`.
 
 ### `CrashListener` (abstract — you implement it)
 
@@ -239,6 +354,30 @@ Everything lives in the `com.osama.firecrasher` package.
 
 `LEVEL_ONE` · `LEVEL_TWO` · `LEVEL_THREE` — the recovery escalation ladder
 described [above](#how-recovery-works).
+
+## What's new in 2.2.0
+
+- **Crash-loop breaker, on by default.** After 10 caught crashes within 60
+  seconds, FireCrasher stops recovering and lets the app die exactly as it
+  would without the library — your crash reporter still receives the fatal.
+  This is a deliberate behavioral change; restore the old behavior with
+  `FireCrasherConfig.Builder().disableCrashLoopBreaker()`.
+- **Configurable recovery policy.** `FireCrasherConfig` controls the
+  LEVEL_ONE retry threshold (`setLevelOneRetries`), which throwables are
+  recovered (`setShouldRecover`), and the loop breaker.
+- **Lambda install with rich crash context.**
+  `FireCrasher.install(app) { crash -> … }` delivers a `CrashEvent` carrying
+  the throwable, crashed thread, foreground activity, retry count, and
+  suggested level — no subclass needed. `FireCrasher.recover()` is now
+  callable without arguments.
+- **Single-activity / Compose support.** `setBackStackDepthProvider` lets a
+  single-activity app report its navigation depth so LEVEL_TWO (go back) can
+  pop a Compose destination instead of restarting the whole app.
+- **`uninstall()`.** Fully reversible installation — restore the previous
+  handler and main loop for kill switches, A/B tests, and test isolation.
+- **Previous handler chaining (fix).** `install()` now captures the
+  previously installed default exception handler instead of silently
+  replacing it; any crash FireCrasher declines to recover reaches it.
 
 ## What's new in 2.1.0
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId = "com.osama.firecrasherdemo"
         minSdk = 23
         targetSdk = 36
-        versionCode = 14
-        versionName = "2.0.0"
+        versionCode = 15
+        versionName = "2.2.0"
     }
     buildTypes {
         release {

--- a/app/src/main/java/com/osama/firecrasherdemo/App.kt
+++ b/app/src/main/java/com/osama/firecrasherdemo/App.kt
@@ -6,9 +6,10 @@ import android.widget.FrameLayout
 import android.widget.Toast
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.progressindicator.CircularProgressIndicator
+import com.osama.firecrasher.CrashEvent
 import com.osama.firecrasher.CrashLevel
-import com.osama.firecrasher.CrashListener
 import com.osama.firecrasher.FireCrasher
+import com.osama.firecrasher.FireCrasherConfig
 
 
 /**
@@ -17,68 +18,79 @@ import com.osama.firecrasher.FireCrasher
 class App : Application() {
     override fun onCreate() {
         super.onCreate()
-        FireCrasher.install(this, object : CrashListener() {
 
-            override fun onCrash(throwable: Throwable) {
+        val config = FireCrasherConfig.Builder()
+            // Never absorb JVM errors: the "Throw Error" button kills the app
+            // normally, exactly as it would without FireCrasher installed.
+            .setShouldRecover { it !is Error }
+            // The "Crash loop" button trips this and lets the app die instead
+            // of recovering forever.
+            .setCrashLoopBreaker(5, 30_000L)
+            .build()
 
-                evaluate { activity, crashLevel ->
-                    val context = activity ?: return@evaluate
-                    if (FireCrasher.retryCount <= 1 && crashLevel == CrashLevel.LEVEL_ONE) {
-                        val padding = (24 * context.resources.displayMetrics.density).toInt()
-                        val progress = FrameLayout(context).apply {
-                            setPadding(padding, padding, padding, padding)
-                            addView(
-                                CircularProgressIndicator(context).apply { isIndeterminate = true },
-                                FrameLayout.LayoutParams(
-                                    FrameLayout.LayoutParams.WRAP_CONTENT,
-                                    FrameLayout.LayoutParams.WRAP_CONTENT,
-                                    Gravity.CENTER
-                                )
-                            )
-                        }
-                        MaterialAlertDialogBuilder(context)
-                            .setTitle("loading")
-                            .setView(progress)
-                            .setCancelable(false)
-                            .show()
-                        recover {
-                            Toast.makeText(this@App, "recover", Toast.LENGTH_LONG).show()
-                        }
-                    } else {
-                        val title = when (crashLevel) {
-                            CrashLevel.LEVEL_ONE -> "Crash Level One"
-                            CrashLevel.LEVEL_TWO -> "Crash Level Two"
-                            CrashLevel.LEVEL_THREE -> "Crash Level Three"
-                        }
+        FireCrasher.install(this, config) { crash ->
+            // Report to your crash reporting tool here, e.g.
+            // FirebaseCrashlytics.getInstance().recordException(crash.throwable)
+            showRecoveryUx(crash)
+        }
 
-                        val positiveButtonText = when (crashLevel) {
-                            CrashLevel.LEVEL_ONE -> "Retry"
-                            CrashLevel.LEVEL_TWO -> "Go Back"
-                            CrashLevel.LEVEL_THREE -> "Restart The App"
-                        }
-                        val builder = MaterialAlertDialogBuilder(context)
-                        builder.setTitle(title)
-                        builder.setMessage(throwable.localizedMessage)
-                        builder.setPositiveButton(positiveButtonText) { _, _ ->
-                            recover {
-                                Toast.makeText(this@App, "recover", Toast.LENGTH_LONG).show()
-                            }
-                        }
-                        if (crashLevel != CrashLevel.LEVEL_THREE)
-                            builder.setNegativeButton("Restart The App") { _, _ ->
-                                recover(CrashLevel.LEVEL_THREE) {
-                                    Toast.makeText(this@App, "recover", Toast.LENGTH_LONG).show()
-                                }
-                            }
-                        builder.setIcon(android.R.drawable.ic_dialog_alert)
-                        builder.show()
-                    }
-                }
+        // The pre-2.2.0 CrashListener API still works unchanged:
+        //
+        // FireCrasher.install(this, object : CrashListener() {
+        //     override fun onCrash(throwable: Throwable) {
+        //         recover()
+        //     }
+        // })
+    }
 
-
-                //you need to add your crash reporting tool here
-                //Ex: Crashlytics.logException(throwable);
+    private fun showRecoveryUx(crash: CrashEvent) {
+        val context = crash.activity ?: return
+        if (crash.retryCount <= 1 && crash.suggestedLevel == CrashLevel.LEVEL_ONE) {
+            val padding = (24 * context.resources.displayMetrics.density).toInt()
+            val progress = FrameLayout(context).apply {
+                setPadding(padding, padding, padding, padding)
+                addView(
+                    CircularProgressIndicator(context).apply { isIndeterminate = true },
+                    FrameLayout.LayoutParams(
+                        FrameLayout.LayoutParams.WRAP_CONTENT,
+                        FrameLayout.LayoutParams.WRAP_CONTENT,
+                        Gravity.CENTER
+                    )
+                )
             }
-        })
+            MaterialAlertDialogBuilder(context)
+                .setTitle("Recovering…")
+                .setView(progress)
+                .setCancelable(false)
+                .show()
+            crash.recover()
+            Toast.makeText(this, "Recovered on this screen", Toast.LENGTH_LONG).show()
+        } else {
+            val title = when (crash.suggestedLevel) {
+                CrashLevel.LEVEL_ONE -> "Crash Level One"
+                CrashLevel.LEVEL_TWO -> "Crash Level Two"
+                CrashLevel.LEVEL_THREE -> "Crash Level Three"
+            }
+
+            val positiveButtonText = when (crash.suggestedLevel) {
+                CrashLevel.LEVEL_ONE -> "Retry"
+                CrashLevel.LEVEL_TWO -> "Go Back"
+                CrashLevel.LEVEL_THREE -> "Restart The App"
+            }
+            val builder = MaterialAlertDialogBuilder(context)
+            builder.setTitle(title)
+            builder.setMessage(crash.throwable.localizedMessage)
+            builder.setPositiveButton(positiveButtonText) { _, _ ->
+                crash.recover()
+                Toast.makeText(this, "Recovered", Toast.LENGTH_LONG).show()
+            }
+            if (crash.suggestedLevel != CrashLevel.LEVEL_THREE)
+                builder.setNegativeButton("Restart The App") { _, _ ->
+                    crash.recover(CrashLevel.LEVEL_THREE)
+                    Toast.makeText(this, "Restarted the app", Toast.LENGTH_LONG).show()
+                }
+            builder.setIcon(android.R.drawable.ic_dialog_alert)
+            builder.show()
+        }
     }
 }

--- a/app/src/main/java/com/osama/firecrasherdemo/MainActivity.java
+++ b/app/src/main/java/com/osama/firecrasherdemo/MainActivity.java
@@ -17,6 +17,20 @@ public class MainActivity extends Activity {
         throw new Exception();
     }
 
+    // The demo config's shouldRecover predicate declines Errors, so this kills
+    // the app exactly as it would without FireCrasher installed.
+    public void throwError(View view) {
+        throw new OutOfMemoryError("demo error - not recovered");
+    }
+
+    // Posts itself again after every recovery; the demo config's crash-loop
+    // breaker (5 crashes / 30s) gives up and lets the app die.
+    public void crashLoop(View view) {
+        View button = findViewById(R.id.buttonCrashLoop);
+        button.postDelayed(() -> crashLoop(button), 500);
+        throw new IllegalStateException("demo crash loop");
+    }
+
     public void next(View view) {
         startActivity(new Intent(this, Main2Activity.class));
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -27,4 +27,22 @@
         android:layout_alignParentEnd="true"
         android:onClick="next"
         android:text="@string/next" />
+
+    <Button
+        android:id="@+id/buttonThrowError"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/button"
+        android:layout_centerHorizontal="true"
+        android:onClick="throwError"
+        android:text="@string/throw_error" />
+
+    <Button
+        android:id="@+id/buttonCrashLoop"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/buttonThrowError"
+        android:layout_centerHorizontal="true"
+        android:onClick="crashLoop"
+        android:text="@string/crash_loop" />
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,6 @@
     <string name="title_activity_main2">Main2Activity</string>
     <string name="crash">Crash</string>
     <string name="next">next</string>
+    <string name="throw_error">Throw Error (dies normally)</string>
+    <string name="crash_loop">Crash loop (trips the breaker)</string>
 </resources>

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -26,5 +26,5 @@ cp -r docs/skills/{install-firecrasher,report-crashes,customize-recovery,detect-
 | `customize-recovery` | Inspect the crash level and show your own recovery UX. |
 | `detect-native-crashes-and-anrs` | Report native crashes / ANRs the in-process handler can't catch (API 30+). |
 
-All snippets target the public API of FireCrasher **2.1.0** (minSdk 23). See the
+All snippets target the public API of FireCrasher **2.2.0** (minSdk 23). See the
 project [`README.md`](../../README.md) for the full reference.

--- a/firecrasher/AGENTS.md
+++ b/firecrasher/AGENTS.md
@@ -33,7 +33,7 @@ editing the library.
 - **Reproducible archives** (`preserveFileTimestamps = false`,
   `reproducibleFileOrder = true`) — JitPack consumes AARs by checksum. Keep it.
 - **Version bumps** must keep `VERSION_NAME` (in `build.gradle`, currently
-  `2.1.0`), the ABI baseline, and the README version in sync.
+  `2.2.0`), the ABI baseline, and the README version in sync.
 
 ## Tests (`src/test/java/...`)
 

--- a/firecrasher/api/firecrasher.api
+++ b/firecrasher/api/firecrasher.api
@@ -1,3 +1,17 @@
+public abstract interface class com/osama/firecrasher/BackStackDepthProvider {
+	public abstract fun getDepth ()I
+}
+
+public final class com/osama/firecrasher/CrashEvent {
+	public final fun getActivity ()Landroid/app/Activity;
+	public final fun getRetryCount ()I
+	public final fun getSuggestedLevel ()Lcom/osama/firecrasher/CrashLevel;
+	public final fun getThread ()Ljava/lang/Thread;
+	public final fun getThrowable ()Ljava/lang/Throwable;
+	public final fun recover ()V
+	public final fun recover (Lcom/osama/firecrasher/CrashLevel;)V
+}
+
 public final class com/osama/firecrasher/CrashHandler : java/lang/Thread$UncaughtExceptionHandler {
 	public fun getActivity ()Landroid/app/Activity;
 	public fun getBackStackCount ()I
@@ -35,7 +49,39 @@ public final class com/osama/firecrasher/FireCrasher {
 	public static final fun getLastAbnormalExit (Landroid/content/Context;)Landroid/app/ApplicationExitInfo;
 	public final fun getRetryCount ()I
 	public final fun install (Landroid/app/Application;Lcom/osama/firecrasher/CrashListener;)V
+	public final fun install (Landroid/app/Application;Lcom/osama/firecrasher/FireCrasherConfig;Lcom/osama/firecrasher/CrashListener;)V
+	public final fun install (Landroid/app/Application;Lcom/osama/firecrasher/FireCrasherConfig;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun install$default (Lcom/osama/firecrasher/FireCrasher;Landroid/app/Application;Lcom/osama/firecrasher/FireCrasherConfig;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun recover (Lcom/osama/firecrasher/CrashLevel;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun recover$default (Lcom/osama/firecrasher/FireCrasher;Lcom/osama/firecrasher/CrashLevel;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun uninstall ()V
+}
+
+public final class com/osama/firecrasher/FireCrasherConfig {
+	public static final field Companion Lcom/osama/firecrasher/FireCrasherConfig$Companion;
+	public static final field DEFAULT Lcom/osama/firecrasher/FireCrasherConfig;
+	public synthetic fun <init> (ILcom/osama/firecrasher/RecoveryPredicate;IJLcom/osama/firecrasher/BackStackDepthProvider;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getBackStackDepthProvider ()Lcom/osama/firecrasher/BackStackDepthProvider;
+	public final fun getCrashLoopThreshold ()I
+	public final fun getCrashLoopWindowMillis ()J
+	public final fun getLevelOneRetries ()I
+	public final fun getShouldRecover ()Lcom/osama/firecrasher/RecoveryPredicate;
+}
+
+public final class com/osama/firecrasher/FireCrasherConfig$Builder {
+	public fun <init> ()V
+	public final fun build ()Lcom/osama/firecrasher/FireCrasherConfig;
+	public final fun disableCrashLoopBreaker ()Lcom/osama/firecrasher/FireCrasherConfig$Builder;
+	public final fun setBackStackDepthProvider (Lcom/osama/firecrasher/BackStackDepthProvider;)Lcom/osama/firecrasher/FireCrasherConfig$Builder;
+	public final fun setCrashLoopBreaker (IJ)Lcom/osama/firecrasher/FireCrasherConfig$Builder;
+	public final fun setLevelOneRetries (I)Lcom/osama/firecrasher/FireCrasherConfig$Builder;
+	public final fun setShouldRecover (Lcom/osama/firecrasher/RecoveryPredicate;)Lcom/osama/firecrasher/FireCrasherConfig$Builder;
+}
+
+public final class com/osama/firecrasher/FireCrasherConfig$Companion {
+}
+
+public abstract interface class com/osama/firecrasher/RecoveryPredicate {
+	public abstract fun shouldRecover (Ljava/lang/Throwable;)Z
 }
 

--- a/firecrasher/build.gradle
+++ b/firecrasher/build.gradle
@@ -108,7 +108,7 @@ afterEvaluate {
                 // com.github.<user> group and git-tag version when it builds.
                 groupId = 'com.osama.firecrasher'
                 artifactId = 'firecrasher'
-                version = project.findProperty('VERSION_NAME') ?: '2.1.0'
+                version = project.findProperty('VERSION_NAME') ?: '2.2.0'
 
                 pom {
                     name = 'firecrasher'

--- a/firecrasher/src/main/java/com/osama/firecrasher/CrashEvent.kt
+++ b/firecrasher/src/main/java/com/osama/firecrasher/CrashEvent.kt
@@ -1,0 +1,35 @@
+package com.osama.firecrasher
+
+import android.app.Activity
+
+/**
+ * Everything known about a caught crash, delivered to the lambda passed to
+ * [FireCrasher.install]. Report [throwable] to your crash reporter, then call
+ * [recover].
+ *
+ * The constructor is internal so new context can be added in future releases
+ * without breaking binary compatibility.
+ */
+public class CrashEvent internal constructor(
+    /** The uncaught exception. */
+    public val throwable: Throwable,
+    /** The thread the exception was raised on. */
+    public val thread: Thread,
+    /** The activity in the foreground when the crash happened, if any. */
+    public val activity: Activity?,
+    /** How many times recovery has already retried the current crash. */
+    public val retryCount: Int,
+    /** The recovery level [recover] would use right now. */
+    public val suggestedLevel: CrashLevel,
+) {
+
+    /** Run recovery at [suggestedLevel]. */
+    public fun recover() {
+        FireCrasher.recover()
+    }
+
+    /** Run recovery at a forced [level]. */
+    public fun recover(level: CrashLevel) {
+        FireCrasher.recover(level)
+    }
+}

--- a/firecrasher/src/main/java/com/osama/firecrasher/CrashHandler.java
+++ b/firecrasher/src/main/java/com/osama/firecrasher/CrashHandler.java
@@ -5,12 +5,42 @@ import android.app.Application;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.Process;
+import android.util.Log;
+
+import java.util.ArrayDeque;
 
 public final class CrashHandler implements Thread.UncaughtExceptionHandler {
+    private static final String TAG = "FireCrasher";
+
+    /** Clock abstraction so crash-loop tests can control time (java.util.function needs API 24+). */
+    interface Clock {
+        long now();
+    }
+
+    /** How the process dies when recovery is declined and no previous handler exists. */
+    interface ProcessTerminator {
+        void terminate(Throwable throwable);
+    }
+
     private Activity activity;
     private int activityCount;
     private Application.ActivityLifecycleCallbacks lifecycleCallbacks;
     private CrashListener crashListener;
+    private Thread crashedThread;
+    private FireCrasherConfig config = FireCrasherConfig.DEFAULT;
+    private Thread.UncaughtExceptionHandler previousDefaultHandler;
+    private final ArrayDeque<Long> crashTimestamps = new ArrayDeque<>();
+
+    Clock clock = System::currentTimeMillis;
+
+    // Mirrors the framework's KillApplicationHandler; injectable so Robolectric
+    // tests exercising the die-path don't kill the test JVM.
+    ProcessTerminator processTerminator = throwable -> {
+        Log.e(TAG, "FATAL EXCEPTION (recovery declined)", throwable);
+        Process.killProcess(Process.myPid());
+        System.exit(10);
+    };
 
     CrashHandler() {
         lifecycleCallbacks = new Application.ActivityLifecycleCallbacks() {
@@ -64,9 +94,41 @@ public final class CrashHandler implements Thread.UncaughtExceptionHandler {
         this.crashListener = crashListener;
     }
 
+    void setConfig(FireCrasherConfig config) {
+        this.config = config;
+    }
+
+    void setPreviousDefaultHandler(Thread.UncaughtExceptionHandler handler) {
+        this.previousDefaultHandler = handler;
+    }
+
+    Thread.UncaughtExceptionHandler getPreviousDefaultHandler() {
+        return previousDefaultHandler;
+    }
+
+    Thread getCrashedThread() {
+        return crashedThread;
+    }
+
+    void reset() {
+        activity = null;
+        activityCount = 0;
+        crashListener = null;
+        crashedThread = null;
+        config = FireCrasherConfig.DEFAULT;
+        previousDefaultHandler = null;
+        crashTimestamps.clear();
+        clock = System::currentTimeMillis;
+    }
+
     @Override
     public void uncaughtException(Thread thread, final Throwable throwable) {
         if (crashListener == null) return;
+        crashedThread = thread;
+        if (!shouldRecover(throwable) || isCrashLooping()) {
+            dieNormally(thread, throwable);
+            return;
+        }
         if (activity != null) {
             activity.runOnUiThread(() -> crashListener.onCrash(throwable));
         } else {
@@ -74,6 +136,47 @@ public final class CrashHandler implements Thread.UncaughtExceptionHandler {
             // or from a background thread at startup): still deliver the callback
             // on the main thread instead of throwing an NPE inside the handler.
             new Handler(Looper.getMainLooper()).post(() -> crashListener.onCrash(throwable));
+        }
+    }
+
+    private boolean shouldRecover(Throwable throwable) {
+        try {
+            return config.getShouldRecover().shouldRecover(throwable);
+        } catch (Throwable predicateFailure) {
+            // A broken predicate must not turn every crash fatal; fall back to
+            // the default of recovering.
+            Log.w(TAG, "shouldRecover predicate threw; recovering anyway", predicateFailure);
+            return true;
+        }
+    }
+
+    // Sliding-window crash-loop breaker: once `crashLoopThreshold` crashes have
+    // been caught within `crashLoopWindowMillis`, recovery has demonstrably
+    // stopped working and the app should die as it would without FireCrasher.
+    private boolean isCrashLooping() {
+        int threshold = config.getCrashLoopThreshold();
+        if (threshold <= 0) return false;
+        long now = clock.now();
+        crashTimestamps.addLast(now);
+        long windowStart = now - config.getCrashLoopWindowMillis();
+        while (!crashTimestamps.isEmpty() && crashTimestamps.peekFirst() < windowStart) {
+            crashTimestamps.removeFirst();
+        }
+        return crashTimestamps.size() >= threshold;
+    }
+
+    // The crash proceeds as if FireCrasher were not installed: the handler that
+    // was the process default before install() (typically a crash reporter's,
+    // which records the fatal and then kills the process) gets the exception;
+    // without one, kill the process the way the framework would.
+    //
+    // On the main thread this runs inside FireLooper's catch, which reposts the
+    // loop afterwards — harmless while the process is dying.
+    private void dieNormally(Thread thread, Throwable throwable) {
+        if (previousDefaultHandler != null && previousDefaultHandler != this) {
+            previousDefaultHandler.uncaughtException(thread, throwable);
+        } else {
+            processTerminator.terminate(throwable);
         }
     }
 

--- a/firecrasher/src/main/java/com/osama/firecrasher/FireCrasher.kt
+++ b/firecrasher/src/main/java/com/osama/firecrasher/FireCrasher.kt
@@ -24,24 +24,105 @@ public object FireCrasher {
 
     private var application: Application? = null
 
+    private var config: FireCrasherConfig = FireCrasherConfig.DEFAULT
+
     private val crashHandler: CrashHandler by lazy { CrashHandler() }
 
     public fun install(application: Application, crashListener: CrashListener) {
+        install(application, FireCrasherConfig.DEFAULT, crashListener)
+    }
+
+    /**
+     * Install with a lambda instead of a [CrashListener] subclass. The lambda
+     * receives a [CrashEvent] carrying the throwable plus the crash context
+     * (thread, activity, retry count, suggested level) and starts recovery via
+     * [CrashEvent.recover]. Use the [CrashListener] overloads when you also
+     * need [CrashListener.onPreviousProcessExit].
+     */
+    public fun install(
+        application: Application,
+        config: FireCrasherConfig = FireCrasherConfig.DEFAULT,
+        onCrash: (CrashEvent) -> Unit,
+    ) {
+        install(application, config, asListener(onCrash))
+    }
+
+    public fun install(
+        application: Application,
+        config: FireCrasherConfig,
+        crashListener: CrashListener,
+    ) {
+        install(application, config, crashListener, hookMainLooper = true)
+    }
+
+    // hookMainLooper=false is a test seam: FireLooper's replacement loop blocks
+    // in MessageQueue.next() by design (it replaces Looper.loop()), which under
+    // Robolectric would park the sandbox main thread forever.
+    internal fun install(
+        application: Application,
+        config: FireCrasherConfig,
+        crashListener: CrashListener,
+        hookMainLooper: Boolean,
+    ) {
         if (FireLooper.isSafe) return
         this.application = application
+        this.config = config
         crashHandler.setCrashListener(crashListener)
+        crashHandler.setConfig(config)
+        // Capture whatever handler was installed before us (a crash reporter's,
+        // or the framework's) so non-recovered crashes still reach it instead
+        // of being silently clobbered. Guard against a repeated install
+        // capturing FireCrasher itself.
+        val currentDefault = Thread.getDefaultUncaughtExceptionHandler()
+        if (currentDefault !== crashHandler) {
+            crashHandler.setPreviousDefaultHandler(currentDefault)
+        }
         application.registerActivityLifecycleCallbacks(crashHandler.lifecycleCallbacks)
         restorePreviousRecoveryState(application, crashListener)
-        FireLooper.install()
+        if (hookMainLooper) FireLooper.install()
         FireLooper.setUncaughtExceptionHandler(crashHandler)
         Thread.setDefaultUncaughtExceptionHandler(crashHandler)
     }
 
-    public fun evaluate(): CrashLevel = evaluate(retryCount, crashHandler.backStackCount)
+    internal fun asListener(onCrash: (CrashEvent) -> Unit): CrashListener =
+        object : CrashListener() {
+            override fun onCrash(throwable: Throwable) {
+                onCrash(buildCrashEvent(throwable))
+            }
+        }
 
-    internal fun evaluate(retryCount: Int, backStackCount: Int): CrashLevel {
+    /**
+     * Undo [install]: restore the uncaught-exception handler that was the
+     * process default before FireCrasher, stop the exception-surviving main
+     * loop at its next message, and stop tracking activities. Subsequent
+     * crashes behave as if FireCrasher was never installed. Safe to call when
+     * not installed; [install] may be called again afterwards.
+     *
+     * Do not call from inside [CrashListener.onCrash] — the crash being
+     * handled still needs the recovery machinery.
+     */
+    public fun uninstall() {
+        application?.unregisterActivityLifecycleCallbacks(crashHandler.lifecycleCallbacks)
+        if (Thread.getDefaultUncaughtExceptionHandler() === crashHandler) {
+            Thread.setDefaultUncaughtExceptionHandler(crashHandler.previousDefaultHandler)
+        }
+        FireLooper.uninstall()
+        retryCount = 0
+        config = FireCrasherConfig.DEFAULT
+        application = null
+        crashHandler.reset()
+    }
+
+    public fun evaluate(): CrashLevel =
+        evaluate(retryCount, currentBackStackDepth(), config.levelOneRetries)
+
+    internal fun evaluate(
+        retryCount: Int,
+        backStackCount: Int,
+        levelOneRetries: Int = FireCrasherConfig.DEFAULT.levelOneRetries,
+    ): CrashLevel {
         return when {
-            retryCount <= 1 ->
+            retryCount < levelOneRetries ->
                 //try to restart the failing activity
                 CrashLevel.LEVEL_ONE
             backStackCount >= 1 ->
@@ -53,11 +134,22 @@ public object FireCrasher {
         }
     }
 
+    private fun currentBackStackDepth(): Int =
+        config.backStackDepthProvider?.getDepth() ?: crashHandler.backStackCount
+
+    internal fun buildCrashEvent(throwable: Throwable): CrashEvent = CrashEvent(
+        throwable = throwable,
+        thread = crashHandler.crashedThread ?: Thread.currentThread(),
+        activity = crashHandler.activity,
+        retryCount = retryCount,
+        suggestedLevel = evaluate(),
+    )
+
     public fun evaluateAsync(onEvaluate: ((activity: Activity?, level: CrashLevel) -> Unit)?) {
         onEvaluate?.invoke(crashHandler.activity, evaluate())
     }
 
-    public fun recover(level: CrashLevel = evaluate(), onRecover: ((activity: Activity?) -> Unit)?) {
+    public fun recover(level: CrashLevel = evaluate(), onRecover: ((activity: Activity?) -> Unit)? = null) {
         val activityPair = getActivityPair()
         val retryCountAtCrash = retryCount
         when (level) {
@@ -204,7 +296,10 @@ public object FireCrasher {
     }
 
     internal fun resetForTest() {
+        application?.unregisterActivityLifecycleCallbacks(crashHandler.lifecycleCallbacks)
         retryCount = 0
         application = null
+        config = FireCrasherConfig.DEFAULT
+        crashHandler.reset()
     }
 }

--- a/firecrasher/src/main/java/com/osama/firecrasher/FireCrasherConfig.kt
+++ b/firecrasher/src/main/java/com/osama/firecrasher/FireCrasherConfig.kt
@@ -1,0 +1,107 @@
+package com.osama.firecrasher
+
+/**
+ * Decides whether FireCrasher should recover from a caught throwable. Return
+ * `false` to let the crash proceed as if FireCrasher were not installed: the
+ * previously installed default handler (e.g. a crash reporter's) runs and the
+ * process dies normally.
+ *
+ * The default recovers everything. A common stricter policy is to never absorb
+ * JVM errors: `RecoveryPredicate { it !is VirtualMachineError }` (Kotlin) or
+ * `t -> !(t instanceof VirtualMachineError)` (Java).
+ */
+public fun interface RecoveryPredicate {
+    public fun shouldRecover(throwable: Throwable): Boolean
+}
+
+/**
+ * Supplies the logical back-stack depth used to pick between going back
+ * ([CrashLevel.LEVEL_TWO]) and restarting the app ([CrashLevel.LEVEL_THREE]).
+ *
+ * By default FireCrasher counts live activities, which is right for
+ * multi-activity apps but always reports zero depth in a single-activity
+ * (e.g. Jetpack Compose + Navigation) app. Provide the depth of your own
+ * navigation stack instead — for Navigation Compose:
+ * `BackStackDepthProvider { if (navController.previousBackStackEntry != null) 1 else 0 }`.
+ * Going back is dispatched through `OnBackPressedDispatcher`, which pops the
+ * Compose destination.
+ */
+public fun interface BackStackDepthProvider {
+    public fun getDepth(): Int
+}
+
+/**
+ * Tuning knobs for the recovery policy. Obtain via [Builder]; pass to
+ * [FireCrasher.install]. [DEFAULT] preserves FireCrasher's historical
+ * behavior except for the crash-loop breaker, which is on by default.
+ */
+public class FireCrasherConfig private constructor(
+    /** Crashes absorbed by restarting the same activity before escalating past [CrashLevel.LEVEL_ONE]. */
+    public val levelOneRetries: Int,
+    /** Consulted before recovery; `false` hands the crash to the previous default handler. */
+    public val shouldRecover: RecoveryPredicate,
+    /** Crashes within [crashLoopWindowMillis] that trip the breaker; `0` disables it. */
+    public val crashLoopThreshold: Int,
+    /** Sliding window for the crash-loop breaker. */
+    public val crashLoopWindowMillis: Long,
+    /** Custom back-stack depth source; `null` counts live activities. */
+    public val backStackDepthProvider: BackStackDepthProvider?,
+) {
+
+    public class Builder {
+        private var levelOneRetries: Int = DEFAULT_LEVEL_ONE_RETRIES
+        private var shouldRecover: RecoveryPredicate = RECOVER_EVERYTHING
+        private var crashLoopThreshold: Int = DEFAULT_CRASH_LOOP_THRESHOLD
+        private var crashLoopWindowMillis: Long = DEFAULT_CRASH_LOOP_WINDOW_MILLIS
+        private var backStackDepthProvider: BackStackDepthProvider? = null
+
+        /** How many crashes restart the same activity before escalating. Must be >= 0. */
+        public fun setLevelOneRetries(count: Int): Builder = apply {
+            require(count >= 0) { "levelOneRetries must be >= 0, was $count" }
+            levelOneRetries = count
+        }
+
+        public fun setShouldRecover(predicate: RecoveryPredicate): Builder = apply {
+            shouldRecover = predicate
+        }
+
+        /**
+         * Stop recovering once [maxCrashes] crashes have been caught within
+         * [windowMillis]; the crash then reaches the previous default handler
+         * and the process dies as it would without FireCrasher.
+         */
+        public fun setCrashLoopBreaker(maxCrashes: Int, windowMillis: Long): Builder = apply {
+            require(maxCrashes > 0) { "maxCrashes must be > 0, was $maxCrashes" }
+            require(windowMillis > 0) { "windowMillis must be > 0, was $windowMillis" }
+            crashLoopThreshold = maxCrashes
+            crashLoopWindowMillis = windowMillis
+        }
+
+        /** Restore the pre-2.2.0 behavior of always recovering, however often the app crashes. */
+        public fun disableCrashLoopBreaker(): Builder = apply {
+            crashLoopThreshold = 0
+        }
+
+        public fun setBackStackDepthProvider(provider: BackStackDepthProvider): Builder = apply {
+            backStackDepthProvider = provider
+        }
+
+        public fun build(): FireCrasherConfig = FireCrasherConfig(
+            levelOneRetries = levelOneRetries,
+            shouldRecover = shouldRecover,
+            crashLoopThreshold = crashLoopThreshold,
+            crashLoopWindowMillis = crashLoopWindowMillis,
+            backStackDepthProvider = backStackDepthProvider,
+        )
+    }
+
+    public companion object {
+        private const val DEFAULT_LEVEL_ONE_RETRIES: Int = 2
+        private const val DEFAULT_CRASH_LOOP_THRESHOLD: Int = 10
+        private const val DEFAULT_CRASH_LOOP_WINDOW_MILLIS: Long = 60_000L
+        private val RECOVER_EVERYTHING: RecoveryPredicate = RecoveryPredicate { true }
+
+        @JvmField
+        public val DEFAULT: FireCrasherConfig = Builder().build()
+    }
+}

--- a/firecrasher/src/main/java/com/osama/firecrasher/FireLooper.kt
+++ b/firecrasher/src/main/java/com/osama/firecrasher/FireLooper.kt
@@ -30,9 +30,14 @@ internal class FireLooper : Runnable {
         Binder.clearCallingIdentity()
 
         while (true) try {
-            val message =
-                    next.invoke(queue)
-                            .takeIf { it is Message && it.obj != EXIT } as Message? ?: break
+            val message = next.invoke(queue) as Message? ?: break
+
+            // The EXIT sentinel is posted by uninstall(): leave the loop and
+            // fall back to the framework's Looper.loop(). The message is
+            // dropped, not recycled — Message.recycle() throws on in-use
+            // messages and recycleUnchecked() is hidden; losing one message
+            // object on uninstall is harmless.
+            if (message.obj === EXIT) break
 
             val handler = target.get(message) as? Handler ?: break
             handler.dispatchMessage(message)
@@ -55,8 +60,18 @@ internal class FireLooper : Runnable {
         private var handler: Handler = Handler(Looper.getMainLooper())
 
         internal fun install() {
+            // Drop any EXIT still queued from an uninstall() so it cannot
+            // immediately shut the fresh loop down.
             handler.removeMessages(0, EXIT)
             handler.post(FireLooper())
+        }
+
+        // Ask the running loop to exit at its next queue poll; the framework's
+        // own Looper.loop() takes over from there. No-op if the loop is not
+        // running: the sentinel is consumed by the plain Handler and ignored.
+        internal fun uninstall() {
+            uncaughtExceptionHandler = null
+            handler.sendMessage(handler.obtainMessage(0, EXIT))
         }
 
         internal val isSafe: Boolean

--- a/firecrasher/src/test/java/com/osama/firecrasher/ConfigEvaluationTest.kt
+++ b/firecrasher/src/test/java/com/osama/firecrasher/ConfigEvaluationTest.kt
@@ -1,0 +1,61 @@
+package com.osama.firecrasher
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class ConfigEvaluationTest {
+
+    @Test
+    fun `default threshold matches the historical two-retry behavior`() {
+        val default = FireCrasherConfig.DEFAULT.levelOneRetries
+        assertEquals(CrashLevel.LEVEL_ONE, FireCrasher.evaluate(retryCount = 0, backStackCount = 0, levelOneRetries = default))
+        assertEquals(CrashLevel.LEVEL_ONE, FireCrasher.evaluate(retryCount = 1, backStackCount = 3, levelOneRetries = default))
+        assertEquals(CrashLevel.LEVEL_TWO, FireCrasher.evaluate(retryCount = 2, backStackCount = 1, levelOneRetries = default))
+        assertEquals(CrashLevel.LEVEL_THREE, FireCrasher.evaluate(retryCount = 2, backStackCount = 0, levelOneRetries = default))
+    }
+
+    @Test
+    fun `zero retries skips activity restart entirely`() {
+        assertEquals(CrashLevel.LEVEL_TWO, FireCrasher.evaluate(retryCount = 0, backStackCount = 1, levelOneRetries = 0))
+        assertEquals(CrashLevel.LEVEL_THREE, FireCrasher.evaluate(retryCount = 0, backStackCount = 0, levelOneRetries = 0))
+    }
+
+    @Test
+    fun `a large threshold keeps restarting the activity`() {
+        assertEquals(CrashLevel.LEVEL_ONE, FireCrasher.evaluate(retryCount = 9, backStackCount = 4, levelOneRetries = 10))
+        assertEquals(CrashLevel.LEVEL_TWO, FireCrasher.evaluate(retryCount = 10, backStackCount = 4, levelOneRetries = 10))
+    }
+
+    @Test
+    fun `builder rejects invalid values`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            FireCrasherConfig.Builder().setLevelOneRetries(-1)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            FireCrasherConfig.Builder().setCrashLoopBreaker(0, 1_000L)
+        }
+        assertThrows(IllegalArgumentException::class.java) {
+            FireCrasherConfig.Builder().setCrashLoopBreaker(3, 0L)
+        }
+    }
+
+    @Test
+    fun `builder defaults match the documented policy`() {
+        val config = FireCrasherConfig.Builder().build()
+        assertEquals(2, config.levelOneRetries)
+        assertEquals(10, config.crashLoopThreshold)
+        assertEquals(60_000L, config.crashLoopWindowMillis)
+        assertEquals(true, config.shouldRecover.shouldRecover(RuntimeException()))
+        assertEquals(null, config.backStackDepthProvider)
+    }
+
+    @Test
+    fun `disabling the crash loop breaker zeroes the threshold`() {
+        val config = FireCrasherConfig.Builder()
+            .setCrashLoopBreaker(3, 1_000L)
+            .disableCrashLoopBreaker()
+            .build()
+        assertEquals(0, config.crashLoopThreshold)
+    }
+}

--- a/firecrasher/src/test/java/com/osama/firecrasher/CrashLoopBreakerTest.kt
+++ b/firecrasher/src/test/java/com/osama/firecrasher/CrashLoopBreakerTest.kt
@@ -1,0 +1,91 @@
+package com.osama.firecrasher
+
+import android.app.Activity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CrashLoopBreakerTest {
+
+    private class RecordingListener : CrashListener() {
+        var crashCount: Int = 0
+
+        override fun onCrash(throwable: Throwable) {
+            crashCount++
+        }
+    }
+
+    private class Harness(config: FireCrasherConfig) {
+        val listener = RecordingListener()
+        val handler = CrashHandler()
+        var now: Long = 0L
+        var died: Throwable? = null
+
+        init {
+            handler.setCrashListener(listener)
+            handler.setConfig(config)
+            handler.clock = CrashHandler.Clock { now }
+            handler.setPreviousDefaultHandler { _, throwable -> died = throwable }
+            val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+            handler.lifecycleCallbacks.onActivityResumed(activity)
+        }
+
+        fun crashAt(timeMillis: Long) {
+            now = timeMillis
+            handler.uncaughtException(Thread.currentThread(), RuntimeException("crash@$timeMillis"))
+        }
+    }
+
+    @Test
+    fun `crashes below the threshold keep recovering`() {
+        val harness = Harness(FireCrasherConfig.Builder().setCrashLoopBreaker(3, 1_000L).build())
+
+        harness.crashAt(0L)
+        harness.crashAt(100L)
+
+        assertEquals(2, harness.listener.crashCount)
+        assertNull(harness.died)
+    }
+
+    @Test
+    fun `the threshold crash within the window dies normally`() {
+        val harness = Harness(FireCrasherConfig.Builder().setCrashLoopBreaker(3, 1_000L).build())
+
+        harness.crashAt(0L)
+        harness.crashAt(100L)
+        harness.crashAt(200L)
+
+        assertEquals(2, harness.listener.crashCount)
+        assertEquals("crash@200", harness.died?.message)
+    }
+
+    @Test
+    fun `crashes spread beyond the window keep recovering`() {
+        val harness = Harness(FireCrasherConfig.Builder().setCrashLoopBreaker(3, 1_000L).build())
+
+        harness.crashAt(0L)
+        harness.crashAt(900L)
+        harness.crashAt(1_800L)
+        harness.crashAt(2_700L)
+
+        assertEquals(4, harness.listener.crashCount)
+        assertNull(harness.died)
+    }
+
+    @Test
+    fun `a disabled breaker never trips`() {
+        val harness = Harness(
+            FireCrasherConfig.Builder().disableCrashLoopBreaker().build(),
+        )
+
+        repeat(50) { harness.crashAt(it.toLong()) }
+
+        assertEquals(50, harness.listener.crashCount)
+        assertNull(harness.died)
+    }
+}

--- a/firecrasher/src/test/java/com/osama/firecrasher/LambdaInstallTest.kt
+++ b/firecrasher/src/test/java/com/osama/firecrasher/LambdaInstallTest.kt
@@ -1,0 +1,118 @@
+package com.osama.firecrasher
+
+import android.app.Activity
+import android.app.Application
+import androidx.activity.ComponentActivity
+import androidx.activity.OnBackPressedCallback
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class LambdaInstallTest {
+
+    private var handlerBeforeTest: Thread.UncaughtExceptionHandler? = null
+
+    @Before
+    fun rememberDefaultHandler() {
+        handlerBeforeTest = Thread.getDefaultUncaughtExceptionHandler()
+    }
+
+    @After
+    fun tearDown() {
+        FireCrasher.resetForTest()
+        Thread.setDefaultUncaughtExceptionHandler(handlerBeforeTest)
+    }
+
+    @Test
+    fun `lambda install delivers a complete crash event`() {
+        var event: CrashEvent? = null
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        FireCrasher.install(application, FireCrasherConfig.DEFAULT, FireCrasher.asListener { event = it }, hookMainLooper = false)
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        val boom = RuntimeException("boom")
+
+        // install() made FireCrasher's handler the process default; delivery is
+        // inline because an activity is resumed and we are on the main thread.
+        Thread.getDefaultUncaughtExceptionHandler()!!
+            .uncaughtException(Thread.currentThread(), boom)
+
+        val received = event
+        assertNotNull(received)
+        assertSame(boom, received!!.throwable)
+        assertSame(Thread.currentThread(), received.thread)
+        assertSame(activity, received.activity)
+        assertEquals(0, received.retryCount)
+        assertEquals(CrashLevel.LEVEL_ONE, received.suggestedLevel)
+    }
+
+    @Test
+    fun `crash event recover runs recovery at the forced level`() {
+        var event: CrashEvent? = null
+        var backPressed = false
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        FireCrasher.install(application, FireCrasherConfig.DEFAULT, FireCrasher.asListener { event = it }, hookMainLooper = false)
+        val activity = Robolectric.buildActivity(ComponentActivity::class.java).setup().get()
+        activity.onBackPressedDispatcher.addCallback(object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                backPressed = true
+            }
+        })
+
+        Thread.getDefaultUncaughtExceptionHandler()!!
+            .uncaughtException(Thread.currentThread(), RuntimeException("boom"))
+        event!!.recover(CrashLevel.LEVEL_TWO)
+
+        assertTrue(backPressed)
+    }
+
+    @Test
+    fun `back stack depth provider drives level selection`() {
+        var event: CrashEvent? = null
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val config = FireCrasherConfig.Builder()
+            .setLevelOneRetries(0)
+            // Single-activity app reporting its own navigation depth.
+            .setBackStackDepthProvider { 3 }
+            .build()
+        FireCrasher.install(application, config, FireCrasher.asListener { event = it }, hookMainLooper = false)
+        Robolectric.buildActivity(Activity::class.java).setup()
+
+        Thread.getDefaultUncaughtExceptionHandler()!!
+            .uncaughtException(Thread.currentThread(), RuntimeException("boom"))
+
+        // One live activity means backStackCount would be 0 (LEVEL_THREE);
+        // the provider's depth makes going back viable instead.
+        assertEquals(CrashLevel.LEVEL_TWO, event!!.suggestedLevel)
+        assertEquals(CrashLevel.LEVEL_TWO, FireCrasher.evaluate())
+    }
+
+    @Test
+    fun `install captures the previously installed default handler`() {
+        var delegated: Throwable? = null
+        val previous = Thread.UncaughtExceptionHandler { _, throwable -> delegated = throwable }
+        Thread.setDefaultUncaughtExceptionHandler(previous)
+        val application = ApplicationProvider.getApplicationContext<Application>()
+
+        FireCrasher.install(
+            application,
+            FireCrasherConfig.Builder().setShouldRecover { false }.build(),
+            FireCrasher.asListener { },
+            hookMainLooper = false,
+        )
+        Robolectric.buildActivity(Activity::class.java).setup()
+        val boom = RuntimeException("not recoverable")
+        Thread.getDefaultUncaughtExceptionHandler()!!
+            .uncaughtException(Thread.currentThread(), boom)
+
+        assertSame(boom, delegated)
+    }
+}

--- a/firecrasher/src/test/java/com/osama/firecrasher/ShouldRecoverTest.kt
+++ b/firecrasher/src/test/java/com/osama/firecrasher/ShouldRecoverTest.kt
@@ -1,0 +1,89 @@
+package com.osama.firecrasher
+
+import android.app.Activity
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ShouldRecoverTest {
+
+    private class RecordingListener : CrashListener() {
+        var received: Throwable? = null
+
+        override fun onCrash(throwable: Throwable) {
+            received = throwable
+        }
+    }
+
+    private fun handlerWithActivity(listener: CrashListener, config: FireCrasherConfig): CrashHandler {
+        val handler = CrashHandler()
+        handler.setCrashListener(listener)
+        handler.setConfig(config)
+        val activity = Robolectric.buildActivity(Activity::class.java).setup().get()
+        handler.lifecycleCallbacks.onActivityResumed(activity)
+        return handler
+    }
+
+    @Test
+    fun `declined crash goes to the previous default handler, not the listener`() {
+        val listener = RecordingListener()
+        val config = FireCrasherConfig.Builder().setShouldRecover { it !is Error }.build()
+        val handler = handlerWithActivity(listener, config)
+        var delegated: Throwable? = null
+        handler.setPreviousDefaultHandler { _, throwable -> delegated = throwable }
+        val fatal = OutOfMemoryError("no heap")
+
+        handler.uncaughtException(Thread.currentThread(), fatal)
+
+        assertSame(fatal, delegated)
+        assertNull(listener.received)
+    }
+
+    @Test
+    fun `declined crash without a previous handler terminates the process`() {
+        val listener = RecordingListener()
+        val config = FireCrasherConfig.Builder().setShouldRecover { false }.build()
+        val handler = handlerWithActivity(listener, config)
+        var terminated: Throwable? = null
+        handler.processTerminator = CrashHandler.ProcessTerminator { terminated = it }
+        val boom = RuntimeException("boom")
+
+        handler.uncaughtException(Thread.currentThread(), boom)
+
+        assertSame(boom, terminated)
+        assertNull(listener.received)
+    }
+
+    @Test
+    fun `accepted crash is delivered to the listener as before`() {
+        val listener = RecordingListener()
+        val config = FireCrasherConfig.Builder().setShouldRecover { it !is Error }.build()
+        val handler = handlerWithActivity(listener, config)
+        var delegated: Throwable? = null
+        handler.setPreviousDefaultHandler { _, throwable -> delegated = throwable }
+        val boom = RuntimeException("boom")
+
+        handler.uncaughtException(Thread.currentThread(), boom)
+
+        assertSame(boom, listener.received)
+        assertNull(delegated)
+    }
+
+    @Test
+    fun `a throwing predicate falls back to recovering`() {
+        val listener = RecordingListener()
+        val config = FireCrasherConfig.Builder()
+            .setShouldRecover { throw IllegalStateException("broken predicate") }
+            .build()
+        val handler = handlerWithActivity(listener, config)
+        val boom = RuntimeException("boom")
+
+        handler.uncaughtException(Thread.currentThread(), boom)
+
+        assertSame(boom, listener.received)
+    }
+}

--- a/firecrasher/src/test/java/com/osama/firecrasher/UninstallTest.kt
+++ b/firecrasher/src/test/java/com/osama/firecrasher/UninstallTest.kt
@@ -1,0 +1,81 @@
+package com.osama.firecrasher
+
+import android.app.Activity
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class UninstallTest {
+
+    private var handlerBeforeTest: Thread.UncaughtExceptionHandler? = null
+
+    @Before
+    fun rememberDefaultHandler() {
+        handlerBeforeTest = Thread.getDefaultUncaughtExceptionHandler()
+    }
+
+    @After
+    fun tearDown() {
+        FireCrasher.resetForTest()
+        Thread.setDefaultUncaughtExceptionHandler(handlerBeforeTest)
+    }
+
+    @Test
+    fun `uninstall restores the previous default handler`() {
+        val previous = Thread.UncaughtExceptionHandler { _, _ -> }
+        Thread.setDefaultUncaughtExceptionHandler(previous)
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        FireCrasher.install(application, FireCrasherConfig.DEFAULT, FireCrasher.asListener { }, hookMainLooper = false)
+
+        FireCrasher.uninstall()
+
+        assertSame(previous, Thread.getDefaultUncaughtExceptionHandler())
+    }
+
+    @Test
+    fun `uninstall when not installed does not throw`() {
+        FireCrasher.uninstall()
+    }
+
+    @Test
+    fun `crashes after uninstall no longer reach the listener`() {
+        var received: Throwable? = null
+        var delegated: Throwable? = null
+        Thread.setDefaultUncaughtExceptionHandler { _, throwable -> delegated = throwable }
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        FireCrasher.install(application, FireCrasherConfig.DEFAULT, FireCrasher.asListener { received = it.throwable }, hookMainLooper = false)
+        Robolectric.buildActivity(Activity::class.java).setup()
+
+        FireCrasher.uninstall()
+        val boom = RuntimeException("after uninstall")
+        Thread.getDefaultUncaughtExceptionHandler()!!
+            .uncaughtException(Thread.currentThread(), boom)
+
+        assertNull(received)
+        assertSame(boom, delegated)
+    }
+
+    @Test
+    fun `reinstall after uninstall delivers crashes again`() {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        FireCrasher.install(application, FireCrasherConfig.DEFAULT, FireCrasher.asListener { }, hookMainLooper = false)
+        FireCrasher.uninstall()
+
+        var received: Throwable? = null
+        FireCrasher.install(application, FireCrasherConfig.DEFAULT, FireCrasher.asListener { received = it.throwable }, hookMainLooper = false)
+        Robolectric.buildActivity(Activity::class.java).setup()
+        Thread.getDefaultUncaughtExceptionHandler()!!
+            .uncaughtException(Thread.currentThread(), RuntimeException("boom"))
+
+        assertNotNull(received)
+    }
+}


### PR DESCRIPTION
New 2.2.0 feature set ("control the recovery policy"), all additive and
binary-compatible:

- FireCrasherConfig (Builder) with a configurable LEVEL_ONE retry
  threshold, a shouldRecover predicate to decline recovery for chosen
  throwables, a sliding-window crash-loop breaker (on by default:
  10 crashes / 60 s), and a backStackDepthProvider so single-activity /
  Compose apps can report their navigation depth and reach LEVEL_TWO.
- Lambda install: FireCrasher.install(app[, config]) { crash -> ... }
  delivering a CrashEvent (throwable, thread, activity, retryCount,
  suggestedLevel) with recover() shortcuts; recover()'s callback now
  defaults to null so bare FireCrasher.recover() works.
- install() captures the previously installed default exception handler
  instead of clobbering it; declined crashes chain to it (or kill the
  process the way the framework would when none exists).
- uninstall(): restores the previous handler, exits the replacement main
  loop via the (previously vestigial) EXIT sentinel, unregisters
  lifecycle callbacks, and permits reinstall.

22 new Robolectric tests across ConfigEvaluationTest, LambdaInstallTest,
ShouldRecoverTest, CrashLoopBreakerTest, and UninstallTest, using an
internal hookMainLooper=false seam because the real replacement loop
blocks in MessageQueue.next() by design. ABI baseline regenerated
(additive only).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011oLv6UP4wH7g31poTsL5cL